### PR TITLE
Update siren.py

### DIFF
--- a/pikudhaoref/siren.py
+++ b/pikudhaoref/siren.py
@@ -32,7 +32,7 @@ class Siren:
         """
 
         israel_timezone = pytz.timezone("Israel")
-        date = datetime.strptime(raw["datetime"], "%Y-%m-%dT%H:%M:%S")
+        date = datetime.strptime(raw["alertDate"], "%Y-%m-%dT%H:%M:%S")
 
         return cls(
             raw["data"],


### PR DESCRIPTION
The current response for history no longer uses "datetime", but has "alertDate". The current version of PikudHaoref.py fails to fetch history without this change.